### PR TITLE
Adding Cocoapods support

### DIFF
--- a/UsefulBits.podspec
+++ b/UsefulBits.podspec
@@ -1,0 +1,94 @@
+#
+# Be sure to run `pod spec lint UsefulBits.podspec' to ensure this is a
+# valid spec and remove all comments before submitting the spec.
+#
+# To learn more about the attributes see http://docs.cocoapods.org/specification.html
+#
+Pod::Spec.new do |s|
+  s.name         = "UsefulBits"
+  s.version      = "1.0"
+  s.summary      = "A Collection of Useful Cocoa and UIKit Bits."
+  s.homepage     = "https://github.com/kevinoneill/Useful-Bits"
+  # s.screenshots  = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
+
+  # Specify the license type. CocoaPods detects automatically the license file if it is named
+  # 'LICENCE*.*' or 'LICENSE*.*', however if the name is different, specify it.
+  s.license = { :type => "BSD", :file => "License.txt" }
+
+  # Specify the authors of the library, with email addresses. You can often find
+  # the email addresses of the authors by using the SCM log. E.g. $ git log
+  #
+  s.author       = { "Kevin O'Neill" => "kevin@oneill.id.au" }
+
+  # Specify the location from where the source should be retrieved.
+  #
+  s.source       = { :git => "https://github.com/kevinoneill/Useful-Bits.git", :tag => "1.0" }
+
+  # If this Pod runs only on iOS or OS X, then specify the platform and
+  # the deployment target.
+  #
+  # s.platform     = :ios, '5.0'
+
+  # ――― MULTI-PLATFORM VALUES ――――――――――――――――――――――――――――――――――――――――――――――――― #
+
+  # If this Pod runs on both platforms, then specify the deployment
+  # targets.
+  #
+  # s.ios.deployment_target = '5.0'
+  # s.osx.deployment_target = '10.7'
+
+  # A list of file patterns which select the source files that should be
+  # added to the Pods project. If the pattern is a directory then the
+  # path will automatically have '*.{h,m,mm,c,cpp}' appended.
+  #
+  s.source_files = 'UsefulBits', 'UsefulBits/**/*.{h,m}'
+  #s.exclude_files = 'Classes/Exclude'
+
+  # A list of file patterns which select the header files that should be
+  # made available to the application. If the pattern is a directory then the
+  # path will automatically have '*.h' appended.
+  #
+  # If you do not explicitly set the list of public header files,
+  # all headers of source_files will be made public.
+  #
+  # s.public_header_files = 'Classes/**/*.h'
+
+  # A list of resources included with the Pod. These are copied into the
+  # target bundle with a build phase script.
+  #
+  # s.resource  = "icon.png"
+  # s.resources = "Resources/*.png"
+  s.resource = 'UsefulBits/custom-navigation.xib'
+  
+  # A list of paths to preserve after installing the Pod.
+  # CocoaPods cleans by default any file that is not used.
+  # Please don't include documentation, example, and test files.
+  #
+  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+  # Specify a list of frameworks that the application needs to link
+  # against for this Pod to work.
+  #
+  # s.framework  = 'SomeFramework'
+  # s.frameworks = 'SomeFramework', 'AnotherFramework'
+  s.frameworks = 'Security'
+  
+  # Specify a list of libraries that the application needs to link
+  # against for this Pod to work.
+  #
+  # s.library   = 'iconv'
+  # s.libraries = 'iconv', 'xml2'
+
+  # If this Pod uses ARC, specify it like so.
+  #
+  s.requires_arc = false
+
+  # If you need to specify any other build settings, add them to the
+  # xcconfig hash.
+  #
+  # s.xcconfig = { 'HEADER_SEARCH_PATHS' => '$(SDKROOT)/usr/include/libxml2' }
+
+  # Finally, specify any Pods that this Pod depends on.
+  #
+  # s.dependency 'JSONKit', '~> 1.4'
+end


### PR DESCRIPTION
Adding a podspec file for using UsefulBits as a cocoa pod. At present, I've added:

```
pod 'UsefulBits', :git => 'https://github.com/mattconnolly/Useful-Bits.git'
```

To my podfile. I'm working on an iOS project, so I haven't tested this yet for OSX, but it should be okay.

There's already a "1.0" tag in your repo, which this podspec will reference. It seems a requirement to have a tag match the version in the podspec file.
